### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   # Run on pull requests to main


### PR DESCRIPTION
Potential fix for [https://github.com/robsdevcraft/vapr-ballistics/security/code-scanning/5](https://github.com/robsdevcraft/vapr-ballistics/security/code-scanning/5)

The best way to fix this problem is to add a `permissions` block at the root of the workflow to grant the least required privileges to all jobs. Based on inspection of the steps, the only permission likely required is `contents: read`, which grants the workflow the ability to clone and access the repository code. None of the shown jobs perform actions that require writing to the contents, issues, pull requests, or other scopes, so no further write permissions are needed. You should insert the following block immediately beneath the workflow name (or above `on:`):

```yaml
permissions:
  contents: read
```

This setting will apply minimal, scoped permissions for all jobs in the workflow unless they individually override it. No code logic outside the YAML file needs to be changed or imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
